### PR TITLE
Add environment-based DB config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Portal Trabajador
+
+## Requisitos de entorno
+
+Configura las siguientes variables de entorno para que la aplicación se conecte a la base de datos:
+
+- `DB_HOST`: dirección del servidor de MariaDB
+- `DB_NAME`: nombre de la base de datos
+- `DB_USER`: usuario con permisos sobre la base de datos
+- `DB_PASS`: contraseña del usuario
+
+Si alguna variable no está definida, se usarán los valores por defecto indicados en `config/config.php`.

--- a/config/config.php
+++ b/config/config.php
@@ -4,11 +4,11 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
-// Datos de conexión a MariaDB
-$host = 'localhost';          // O la IP de MariaDB si no está en el NAS
-$db   = 'portal_trabajador';  // Nombre de la base de datos
-$user = 'portaluser';            // Usuario de MariaDB (¡cámbialo!)
-$pass = 'Portal2025#';         // Contraseña de ese usuario
+// Datos de conexión a MariaDB obtenidos de variables de entorno
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'portal_trabajador';
+$user = getenv('DB_USER') ?: 'portaluser';
+$pass = getenv('DB_PASS') ?: 'Portal2025#';
 $charset = 'utf8mb4';
 
 // Configuración DSN para PDO


### PR DESCRIPTION
## Summary
- load DB connection details from environment variables in `config/config.php`
- describe the required variables in a new README

## Testing
- `php -l config/config.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a982b46c4832e839e0c259dde7108